### PR TITLE
Fix the build by restricting phpunit for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ tools/box:
 	curl -Ls https://github.com/humbug/box/releases/download/3.4.0/box.phar -o tools/box && chmod +x tools/box
 
 tests/phar/tools/phpunit:
-	curl -Ls https://phar.phpunit.de/phpunit-8.phar -o tests/phar/tools/phpunit && chmod +x tests/phar/tools/phpunit
+	curl -Ls https://phar.phpunit.de/phpunit-8.1.phar -o tests/phar/tools/phpunit && chmod +x tests/phar/tools/phpunit
 
 tests/phar/tools/phpunit.d/zalas-phpunit-doubles-extension.phar: build/zalas-phpunit-doubles-extension.phar
 	cp build/zalas-phpunit-doubles-extension.phar tests/phar/tools/phpunit.d/zalas-phpunit-doubles-extension.phar

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.2",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.0,<8.2",
         "phpdocumentor/reflection-docblock": "^4.0.1"
     },
     "require-dev": {


### PR DESCRIPTION
PHPUnit 8.2.1 fails with:

```
Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\PhpunitTest::test_mock_objects_verify_expectations
InvalidArgumentException: "\PHPUnit\Framework\array<string,array<int,string>>" is not a valid Fqsen.
```