### PR TITLE
Ignore base test case properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /composer.lock
 /vendor/
 /.php_cs.cache
-/.phpunit.result.cache
+.phpunit.result.cache

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ tools/box:
 	curl -Ls https://github.com/humbug/box/releases/download/3.4.0/box.phar -o tools/box && chmod +x tools/box
 
 tests/phar/tools/phpunit:
-	curl -Ls https://phar.phpunit.de/phpunit-8.1.phar -o tests/phar/tools/phpunit && chmod +x tests/phar/tools/phpunit
+	curl -Ls https://phar.phpunit.de/phpunit-8.phar -o tests/phar/tools/phpunit && chmod +x tests/phar/tools/phpunit
 
 tests/phar/tools/phpunit.d/zalas-phpunit-doubles-extension.phar: build/zalas-phpunit-doubles-extension.phar
 	cp build/zalas-phpunit-doubles-extension.phar tests/phar/tools/phpunit.d/zalas-phpunit-doubles-extension.phar

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.2",
-        "phpunit/phpunit": "^8.0,<8.2",
+        "phpunit/phpunit": "^8.0",
         "phpdocumentor/reflection-docblock": "^4.0.1"
     },
     "require-dev": {

--- a/src/PhpDocumentor/ReflectionExtractor.php
+++ b/src/PhpDocumentor/ReflectionExtractor.php
@@ -15,6 +15,19 @@ use Zalas\PHPUnit\Doubles\Extractor\Property;
 final class ReflectionExtractor implements Extractor
 {
     /**
+     * @var string[]
+     */
+    private $ignoredClasses;
+
+    /**
+     * @param string[] $ignoredClasses
+     */
+    public function __construct(array $ignoredClasses)
+    {
+        $this->ignoredClasses = $ignoredClasses;
+    }
+
+    /**
      * @param object   $object
      * @param callable $filter
      *
@@ -41,6 +54,10 @@ final class ReflectionExtractor implements Extractor
      */
     private function mapClassToProperties(\ReflectionClass $class, callable $filter): array
     {
+        if (\in_array($class->getName(), $this->ignoredClasses)) {
+            return [];
+        }
+
         $docBlockFactory = DocBlockFactory::createInstance();
         $classContext = (new ContextFactory())->createFromReflector($class);
 

--- a/src/TestCase/TestDoubles.php
+++ b/src/TestCase/TestDoubles.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Doubles\TestCase;
 
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Zalas\PHPUnit\Doubles\Injector\PropertyAccessInjector;
 use Zalas\PHPUnit\Doubles\PhpDocumentor\ReflectionExtractor;
@@ -21,7 +23,7 @@ trait TestDoubles
     protected function initialiseTestDoubles(): void
     {
         $doubler = new Doubler(
-            new ReflectionExtractor(),
+            new ReflectionExtractor([TestCase::class, Assert::class]),
             new PropertyAccessInjector(),
             [
                 ObjectProphecy::class => function (array $types) {

--- a/tests/PhpDocumentor/ReflectionExtractorTest.php
+++ b/tests/PhpDocumentor/ReflectionExtractorTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Doubles\Tests\PhpDocumentor;
 
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Zalas\PHPUnit\Doubles\Extractor\Extractor;
 use Zalas\PHPUnit\Doubles\Extractor\Property;
@@ -15,16 +16,24 @@ use Zalas\PHPUnit\Doubles\Tests\PhpDocumentor\Fixtures\World\Elephant;
 
 class ReflectionExtractorTest extends TestCase
 {
+    /**
+     * @var ReflectionExtractor
+     */
+    private $extractor;
+
+    protected function setUp(): void
+    {
+        $this->extractor =  new ReflectionExtractor([TestCase::class, Assert::class]);
+    }
+
     public function test_it_is_an_extractor()
     {
-        $this->assertInstanceOf(Extractor::class, new ReflectionExtractor());
+        $this->assertInstanceOf(Extractor::class, $this->extractor);
     }
 
     public function test_it_extracts_properties_from_the_given_object()
     {
-        $extractor = new ReflectionExtractor();
-
-        $properties = $extractor->extract(new Discworld(), function () {
+        $properties = $this->extractor->extract(new Discworld(), function () {
             return true;
         });
 
@@ -40,9 +49,7 @@ class ReflectionExtractorTest extends TestCase
 
     public function test_it_filters_properties_out()
     {
-        $extractor = new ReflectionExtractor();
-
-        $properties = $extractor->extract(new Discworld(), function (Property $property) {
+        $properties = $this->extractor->extract(new Discworld(), function (Property $property) {
             return $property->hasType(Rincewind::class);
         });
 


### PR DESCRIPTION
These [are causing problems](https://github.com/phpDocumentor/ReflectionDocBlock/issues/173) with property extractor. The base test case contains properties we are never interested in anyway.

As a side effect, this step seems to have improved performance.

