### PR TITLE
Support PHPUnit 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,17 @@ class DiscworldTest extends TestCase
     private $vimes;
 
     /**
-     * @var Nobby|Fred|MockObject
+     * @var Nobby|MockObject
      */
     private $nobbyAndFred;
 
     public function test_it_hires_new_recruits_for_nightwatch()
     {
-        $discworld = new Discworld($this->vimes, $this->nobbyAndFred);
+        $discworld = new Discworld($this->vimes, $this->nobby);
 
         $this->vimes->expects($this->once())
             ->method('recruit')
-            ->with($this->nobbyAndFred);
+            ->with($this->nobby);
 
         $discworld->createNightWatch();
     }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.2,<8.0",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.5 || ^9.0",
         "phpdocumentor/reflection-docblock": "^4.0.1"
     },
     "require-dev": {
@@ -28,7 +28,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "1.5.x-dev"
         }
     }
 }

--- a/src/TestCase/TestDoubles.php
+++ b/src/TestCase/TestDoubles.php
@@ -13,7 +13,7 @@ use Zalas\PHPUnit\Doubles\PhpDocumentor\ReflectionExtractor;
 
 trait TestDoubles
 {
-    abstract public function getMockBuilder($className): MockBuilder;
+    abstract public function getMockBuilder(string $className): MockBuilder;
 
     abstract protected function prophesize($classOrInterface = null): ObjectProphecy;
 
@@ -54,7 +54,7 @@ trait TestDoubles
 
     private function createTestDoubleWithPhpunit(array $types): MockObject
     {
-        $normalisedTypes = 1 === \count($types) ? \array_pop($types) : (!empty($types) ? $types : \stdClass::class);
+        $normalisedTypes = \array_shift($types) ?? \stdClass::class;
 
         return $this->getMockBuilder($normalisedTypes)
             ->disableOriginalConstructor()

--- a/tests/TestCase/TestDoubles/PhpunitTest.php
+++ b/tests/TestCase/TestDoubles/PhpunitTest.php
@@ -9,8 +9,6 @@ use Zalas\PHPUnit\Doubles\TestCase\TestDoubles;
 use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\Fixtures\Copper;
 use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\Fixtures\Death;
 use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\Fixtures\Discworld;
-use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\Fixtures\Fred;
-use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\Fixtures\Nobby;
 use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\Fixtures\Vimes;
 
 class PhpunitTest extends TestCase
@@ -23,12 +21,12 @@ class PhpunitTest extends TestCase
     private $vimes;
 
     /**
-     * @var Nobby|Copper|MockObject
+     * @var Copper|MockObject
      */
     private $nobby;
 
     /**
-     * @var Fred|Copper|MockObject
+     * @var Copper|MockObject
      */
     private $fred;
 
@@ -43,8 +41,6 @@ class PhpunitTest extends TestCase
         $this->assertInstanceOf(MockObject::class, $this->nobby);
         $this->assertInstanceOf(MockObject::class, $this->fred);
         $this->assertInstanceOf(Vimes::class, $this->vimes);
-        $this->assertInstanceOf(Nobby::class, $this->nobby);
-        $this->assertInstanceOf(Fred::class, $this->fred);
         $this->assertInstanceOf(Copper::class, $this->nobby);
         $this->assertInstanceOf(Copper::class, $this->fred);
     }


### PR DESCRIPTION
[BC BREAK] PHPUnit 9 no longer allows mocking multiple interfaces, so the following will no longer work:

```
   /**
     * @var Nobby|Copper|MockObject
     */
    private $nobby;
```

Additional interfaces will be ignored.
