### PR TITLE
Added support for PHP 8.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
                 with:
                     php-version: "${{ matrix.php }}"
                     ini-values: "phar.readonly=0"
-                    coverage: none
+                    coverage: pcov
 
             -   name: Test & package
                 if: matrix.deps == 'high'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
         name: Build and test
         strategy:
             matrix:
-                php: ['8.1', '8.2']
+                php: ['8.1', '8.2', '8.3']
                 deps: [high]
                 include:
-                    -   php: '8.2'
+                    -   php: '8.3'
                         deps: low
 
         steps:

--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,10 @@ tools/deptrac:
 	curl -Ls https://github.com/sensiolabs-de/deptrac/releases/download/1.0.2/deptrac.phar -o tools/deptrac && chmod +x tools/deptrac
 
 tools/infection: tools/infection.pubkey
-	curl -Ls https://github.com/infection/infection/releases/download/0.26.16/infection.phar -o tools/infection && chmod +x tools/infection
+	curl -Ls https://github.com/infection/infection/releases/download/0.27.9/infection.phar -o tools/infection && chmod +x tools/infection
 
 tools/infection.pubkey:
-	curl -Ls https://github.com/infection/infection/releases/download/0.26.16/infection.phar.pubkey -o tools/infection.pubkey
+	curl -Ls https://github.com/infection/infection/releases/download/0.27.9/infection.phar.pubkey -o tools/infection.pubkey
 
 tools/box:
 	curl -Ls https://github.com/humbug/box/releases/download/3.16.0/box.phar -o tools/box && chmod +x tools/box

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ deptrac: tools/deptrac
 .PHONY: deptrac
 
 infection: tools/infection tools/infection.pubkey
-	phpdbg -qrr ./tools/infection --no-interaction --formatter=progress --min-msi=100 --min-covered-msi=100 --only-covered --ansi
+	./tools/infection --no-interaction --formatter=progress --min-msi=100 --min-covered-msi=100 --ansi
 .PHONY: infection
 
 phpunit: tools/phpunit

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Initialises test doubles in PHPUnit test cases for you",
     "type": "library",
     "require": {
-        "php": "~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "phpunit/phpunit": "^9.6",
         "phpdocumentor/reflection-docblock": "^5.2"
     },


### PR DESCRIPTION
This PR adds a support for PHP 8.3. 
Infection tools was updated to the latest version (0.27.9) to fix thrown deprecations.
Infection tool is now run without phpdbg because on PHP8.3 it throws errors.