### PR TITLE
Migrate to PHPunit 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /vendor/
 /.php-cs-fixer.cache
 /.deptrac.cache
+/.phpunit.cache
 .phpunit.result.cache

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ tools/box:
 	curl -Ls https://github.com/humbug/box/releases/download/4.6.6/box.phar -o tools/box && chmod +x tools/box
 
 tests/phar/tools/phpunit:
-	curl -Ls https://phar.phpunit.de/phpunit-10.phar -o tests/phar/tools/phpunit && chmod +x tests/phar/tools/phpunit
+	curl -Ls https://phar.phpunit.de/phpunit-11.phar -o tests/phar/tools/phpunit && chmod +x tests/phar/tools/phpunit
 
 tests/phar/tools/phpunit.d/zalas-phpunit-doubles-extension.phar: build/zalas-phpunit-doubles-extension.phar
 	cp build/zalas-phpunit-doubles-extension.phar tests/phar/tools/phpunit.d/zalas-phpunit-doubles-extension.phar

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ deptrac: tools/deptrac
 .PHONY: deptrac
 
 infection: tools/infection tools/infection.pubkey
-	./tools/infection --no-interaction --formatter=progress --min-msi=100 --min-covered-msi=100 --ansi
+	./tools/infection --no-interaction --formatter=progress --min-msi=100 --min-covered-msi=100 --only-covered --ansi
 .PHONY: infection
 
 phpunit: tools/phpunit

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ tools/box:
 	curl -Ls https://github.com/humbug/box/releases/download/4.6.6/box.phar -o tools/box && chmod +x tools/box
 
 tests/phar/tools/phpunit:
-	curl -Ls https://phar.phpunit.de/phpunit-9.phar -o tests/phar/tools/phpunit && chmod +x tests/phar/tools/phpunit
+	curl -Ls https://phar.phpunit.de/phpunit-10.phar -o tests/phar/tools/phpunit && chmod +x tests/phar/tools/phpunit
 
 tests/phar/tools/phpunit.d/zalas-phpunit-doubles-extension.phar: build/zalas-phpunit-doubles-extension.phar
 	cp build/zalas-phpunit-doubles-extension.phar tests/phar/tools/phpunit.d/zalas-phpunit-doubles-extension.phar

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^11.0",
         "phpdocumentor/reflection-docblock": "^5.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "type": "library",
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^10.0",
         "phpdocumentor/reflection-docblock": "^5.2"
     },
     "require-dev": {
-        "phpspec/prophecy-phpunit": "^2.0.1"
+        "phpspec/prophecy-phpunit": "^2.2"
     },
     "conflict": {
         "phpdocumentor/type-resolver": "1.3.0"
@@ -23,6 +23,8 @@
             "Zalas\\PHPUnit\\Doubles\\Tests\\": "tests"
         }
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,6 @@
             "Zalas\\PHPUnit\\Doubles\\Tests\\": "tests"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "license": "MIT",
     "authors": [
         {

--- a/manifest.xml.in
+++ b/manifest.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phar xmlns="https://phar.io/xml/manifest/1.0">
     <contains name="zalas/phpunit-doubles" version="@@version@@" type="extension">
-        <extension for="phpunit/phpunit" compatible="^9.0"/>
+        <extension for="phpunit/phpunit" compatible="^10.0"/>
     </contains>
 
     <copyright>

--- a/manifest.xml.in
+++ b/manifest.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phar xmlns="https://phar.io/xml/manifest/1.0">
     <contains name="zalas/phpunit-doubles" version="@@version@@" type="extension">
-        <extension for="phpunit/phpunit" compatible="^10.0"/>
+        <extension for="phpunit/phpunit" compatible="^11.0"/>
     </contains>
 
     <copyright>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="vendor/autoload.php" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" colors="true" verbose="true">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="vendor/autoload.php" beStrictAboutOutputDuringTests="true" colors="true" cacheDirectory=".phpunit.cache">
+  <coverage>
     <report>
       <clover outputFile="build/coverage.xml"/>
       <html outputDirectory="build/coverage" lowUpperBound="50" highLowerBound="95"/>
@@ -16,4 +13,9 @@
     </testsuite>
   </testsuites>
   <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/TestCase/PHPUnitTestDoubles.php
+++ b/src/TestCase/PHPUnitTestDoubles.php
@@ -37,9 +37,6 @@ trait PHPUnitTestDoubles
         return $this->getMockBuilder($normalisedTypes)
             ->disableOriginalConstructor()
             ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->disableProxyingToOriginalMethods()
-            ->disallowMockingUnknownTypes()
             ->getMock();
     }
 }

--- a/tests/TestCase/TestDoubles/PhpunitTest.php
+++ b/tests/TestCase/TestDoubles/PhpunitTest.php
@@ -10,10 +10,12 @@ use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\Fixtures\Copper;
 use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\Fixtures\Death;
 use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\Fixtures\Discworld;
 use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\Fixtures\Vimes;
+use Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\TestKit\ConsecutiveParams;
 
 class PhpunitTest extends TestCase
 {
     use PHPUnitTestDoubles;
+    use ConsecutiveParams;
 
     /**
      * @var Vimes|MockObject
@@ -49,7 +51,9 @@ class PhpunitTest extends TestCase
     {
         $discworld = new Discworld($this->vimes, [$this->nobby, $this->fred]);
 
-        $this->vimes->expects($this->exactly(2))->method('recruit')->withConsecutive([$this->nobby], [$this->fred]);
+        $this->vimes->expects($this->exactly(2))
+            ->method('recruit')
+            ->with(...$this->consecutiveParams([$this->nobby], [$this->fred]));
 
         $discworld->createNightWatch();
     }

--- a/tests/TestCase/TestDoubles/TestKit/ConsecutiveParams.php
+++ b/tests/TestCase/TestDoubles/TestKit/ConsecutiveParams.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Doubles\Tests\TestCase\TestDoubles\TestKit;
+
+// @see https://gist.github.com/ziadoz/370fe63e24f31fd1eb989e7477b9a472
+trait ConsecutiveParams
+{
+    // @see: https://stackoverflow.com/questions/75389000/replace-phpunit-method-withconsecutive
+    // @see: https://stackoverflow.com/questions/21861825/quick-way-to-find-the-largest-array-in-a-multidimensional-array
+    public function consecutiveParams(array ...$args): array
+    {
+        $callbacks = [];
+        $count = \count(\max($args));
+
+        for ($index = 0; $index < $count; $index++) {
+            $returns = [];
+
+            foreach ($args as $arg) {
+                if (!\array_is_list($arg)) {
+                    throw new \InvalidArgumentException('Every array must be a list');
+                }
+
+                if (!isset($arg[$index])) {
+                    throw new \InvalidArgumentException(\sprintf('Every array must contain %d parameters', $count));
+                }
+
+                $returns[] = $arg[$index];
+            }
+
+            $callbacks[] = $this->callback(new class($returns) {
+                public function __construct(protected array $returns)
+                {
+                }
+
+                public function __invoke(mixed $actual): bool
+                {
+                    if (0 === \count($this->returns)) {
+                        return true;
+                    }
+
+                    return $actual === \array_shift($this->returns);
+                }
+            });
+        }
+
+        return $callbacks;
+    }
+}

--- a/tests/phar/bootstrap.php
+++ b/tests/phar/bootstrap.php
@@ -2,20 +2,86 @@
 
 declare(strict_types=1);
 
-\spl_autoload_register(function ($className) {
-    // Only load this specific namespace. Anything else should be loaded from the phar.
-    if (0 === \strpos($className, 'Zalas\PHPUnit\Doubles\Tests\TestCase\\TestDoubles\\')) {
-        $path = \sprintf('%s/../%s.php', __DIR__, \strtr($className, ['\\' => '/', 'Zalas\PHPUnit\Doubles\Tests\\' => '']));
-
-        if (\file_exists($path)) {
-            require_once $path;
-        }
+class AutoloaderNamespace
+{
+    public function __construct(
+        public readonly string $prefixToMatch,
+        public readonly string $prefixToRemove,
+        public readonly string $pathTemplate,
+    ) {
     }
-    if (0 === \strpos($className, 'Prophecy\PhpUnit\\')) {
-        $path = \sprintf('%s/../../vendor/phpspec/prophecy-phpunit/src/%s.php', __DIR__, \strtr($className, ['\\' => '/', 'Prophecy\PhpUnit\\' => '']));
+}
 
-        if (\file_exists($path)) {
-            require_once $path;
+\spl_autoload_register(function ($className) {
+    // Only load these specific namespaces. Anything else should be loaded from the phar.
+    // These are namespaces that would normally be loaded by project's autoloader, which we do not have here.
+    $namespaces = [
+        new AutoloaderNamespace(
+            'Zalas\PHPUnit\Doubles\Tests\TestCase\\TestDoubles\\',
+            'Zalas\PHPUnit\Doubles\Tests\\',
+            __DIR__ . '/../%s.php'
+        ),
+        new AutoloaderNamespace(
+            'Prophecy\\',
+            'Prophecy\\',
+            __DIR__ . '/../../vendor/phpspec/prophecy/src/Prophecy/%s.php'
+        ),
+        new AutoloaderNamespace(
+            'Prophecy\Prophecy\\',
+            'Prophecy\Prophecy\\',
+            __DIR__ . '/../../vendor/phpspec/prophecy/src/Prophecy/Prophecy/%s.php'
+        ),
+        new AutoloaderNamespace(
+            'Prophecy\PhpUnit\\',
+            'Prophecy\PhpUnit\\',
+            __DIR__ . '/../../vendor/phpspec/prophecy-phpunit/src/%s.php'
+        ),
+        new AutoloaderNamespace(
+            'phpDocumentor\Reflection\\',
+            'phpDocumentor\Reflection\\',
+            __DIR__ . '/../../vendor/phpdocumentor/reflection-docblock/src/%s.php'
+        ),
+        new AutoloaderNamespace(
+            'phpDocumentor\Reflection\\',
+            'phpDocumentor\Reflection\\',
+            __DIR__ . '/../../vendor/phpdocumentor/type-resolver/src/%s.php'
+        ),
+        new AutoloaderNamespace(
+            'PHPStan\PhpDocParser\\',
+            'PHPStan\PhpDocParser\\',
+            __DIR__ . '/../../vendor/phpstan/phpdoc-parser/src/%s.php'
+        ),
+        new AutoloaderNamespace(
+            'Webmozart\Assert\\',
+            'Webmozart\Assert\\',
+            __DIR__ . '/../../vendor/webmozart/assert/src/%s.php'
+        ),
+        new AutoloaderNamespace(
+            'SebastianBergmann\Comparator\\',
+            'SebastianBergmann\Comparator\\',
+            __DIR__ . '/../../vendor/sebastian/comparator/src/%s.php'
+        ),
+        new AutoloaderNamespace(
+            'SebastianBergmann\Exporter\\',
+            'SebastianBergmann\Exporter\\',
+            __DIR__ . '/../../vendor/sebastian/exporter/src/%s.php'
+        ),
+        new AutoloaderNamespace(
+            'SebastianBergmann\RecursionContext\\',
+            'SebastianBergmann\RecursionContext\\',
+            __DIR__ . '/../../vendor/sebastian/recursion-context/src/%s.php'
+        ),
+    ];
+
+    foreach ($namespaces as $namespace) {
+        if (\str_starts_with($className, $namespace->prefixToMatch)) {
+            $path = \sprintf($namespace->pathTemplate, \strtr($className, ['\\' => '/', $namespace->prefixToRemove => '']));
+
+            if (\file_exists($path)) {
+                require_once $path;
+
+                return;
+            }
         }
     }
 });

--- a/tests/phar/phpunit.xml
+++ b/tests/phar/phpunit.xml
@@ -4,7 +4,6 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          bootstrap="bootstrap.php"
-         verbose="true"
          extensionsDirectory="tools/phpunit.d">
     <testsuites>
         <testsuite name="default">


### PR DESCRIPTION
This way, we'll skip support for PHPUnit 10 entirely. It wrongly autoloads test cases, before loading extensions. It wasn't the case in PHPUnit <9, and it isn't the case in PHPUnit 11. I do not have capacity, nor the energy, to debug PHPUnit 10.